### PR TITLE
Update blog post title and description

### DIFF
--- a/_posts/2024-10-14-Github-Actions-Runner-Ubuntu-Latest-PIP.md
+++ b/_posts/2024-10-14-Github-Actions-Runner-Ubuntu-Latest-PIP.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: GitHub Actions Runners - `ubuntu-latest` and PIP
+title: GitHub Actions Runners - Python and the Ubuntu 24.04 image
 date: 2024-09-13 20:00 -0400
 description: >
   Earlier this morning, my team encoutered an error related to a breaking change in python while using the `ubuntu-latest` runner in GitHub Actions.  This post is a quick write-up on how we resolved the issue and what the root cause was.


### PR DESCRIPTION
This pull request includes a change to the title of a blog post to better reflect its content.

* [`_posts/2024-10-14-Github-Actions-Runner-Ubuntu-Latest-PIP.md`](diffhunk://#diff-f77be8008195be04d2b48bd696f090b166000644784cb488231947cc833a59dcL3-R3): Changed the title from "GitHub Actions Runners - `ubuntu-latest` and PIP" to "GitHub Actions Runners - Python and the Ubuntu 24.04 image" to clarify the focus on Python and the specific Ubuntu image version.